### PR TITLE
Fix hydration warning substring

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -12,7 +12,7 @@ export default function Error({
   useEffect(() => {
     // Log error to console for debugging but don't show it to users if it's a hydration error
     if (error.message.includes('Hydration failed') || 
-        error.message.includes('expansion-alids')) {
+        error.message.includes('expansion-ids')) {
       return;
     }
     console.error(error);
@@ -20,7 +20,7 @@ export default function Error({
 
   // Don't show error UI for hydration mismatches
   if (error.message.includes('Hydration failed') || 
-      error.message.includes('expansion-alids')) {
+      error.message.includes('expansion-ids')) {
     return null;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,8 +20,8 @@ export default function RootLayout({
               const originalError = console.error;
               console.error = function(...args) {
                 if (typeof args[0] === 'string' && 
-                    (args[0].includes('Hydration failed') || 
-                     args[0].includes('expansion-alids'))) {
+                    (args[0].includes('Hydration failed') ||
+                     args[0].includes('expansion-ids'))) {
                   return;
                 }
                 originalError.apply(console, args);


### PR DESCRIPTION
## Summary
- adjust console suppression check for hydration warnings
- update error handling logic to match new substring

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f5d51dfa8832d886e5dfa69025e9d